### PR TITLE
Trace requirements from user-provided requirement ID

### DIFF
--- a/stylesheets/network.xsl
+++ b/stylesheets/network.xsl
@@ -10,80 +10,194 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <head>
 <title>Network visualization</title>
 
-<script src="https://code.jquery.com/jquery.min.js"></script>
-<script src=
-"https://visjs.github.io/vis-network/standalone/umd/vis-network.min.js">
-</script>
-
- <style type="text/css">
+<style type="text/css">
 body {
         color: #d3d3d3;
         font: 12pt arial;
         background-color: #222222;
       }
-    #viewer {
+#viewer {
       width: 100%;
       height: 100%;
       border: 1px solid lightgray;
     }
   </style>
-<script>
+<script type="module">
+import 'https://unpkg.com/jquery@3.6.0/dist/jquery.min.js';
+import cytoscape from 'https://unpkg.com/cytoscape@3.21.1/dist/cytoscape.esm.min.js';
+import { Network } from 'https://unpkg.com/vis-network@9.1.2/standalone/esm/vis-network.min.js';
 
-var network = null;
-
-var nodes = [
+const data = [
+<!-- nodes -->
 <xsl:apply-templates select="//*[@id]"/>
-];
-
-const level = {'org': 0, 'ucd': 1, 'sys': 3, 'fnc': 4, 'int': 5, 'pad': 6, 'ver': 7, 'doc': 8};
-
-<![CDATA[
-for (var i= 0; i < nodes.length; ++i) {
-  const this_level = level[nodes[i].group];
-  nodes[i]['level'] = this_level;
-
-  if(this_level == 1 || this_level >= 6) {
-    nodes[i]['mass'] = 5;
-  }
-}
-]]>
-
-const edges = [
+<!-- edges -->
 <xsl:apply-templates select="//trace"/>
 <xsl:apply-templates select="//test"/>
 <xsl:apply-templates select="//interface" mode="link"/>
 <xsl:apply-templates select="//function" mode="link"/>
 ];
 
-function draw(data) {
-    const options = {
-        nodes: {
-          shape: "dot",
-          font: {
-            color: "#ffffff",
-          },
-          borderWidth: 2,
-        },
-        edges: {
-          width: 2,
-        },
-        //layout: {
-        //    hierarchical: {
-        //      direction: 'UD',
-        //      sortMethod: 'directed',
-        //    },
-        //  },
-      };
+function filterNodes(cy, id) {
+  const selected = cy.$(id);
+  const successors = selected.successors();
+  const predecessors = selected.predecessors();
 
-    if (network == null) {
-        network = new vis.Network(document.getElementById('viewer'), data, options);
-    }
+  successors.union(selected).union(predecessors).absoluteComplement().remove();
+  selected.outgoers().select();
+  selected.incomers().select();
 }
 
-$(function () {
-    draw({nodes: nodes, edges: edges});
-})
-    </script>
+// Query the URL for RESTful queries
+// Reference: https://stackoverflow.com/a/901144
+const urlQuery = new Proxy(new URLSearchParams(window.location.search), {
+  get : (searchParams, prop) => searchParams.get(prop),
+});
+
+// Cytoscape.js visualization themes
+const style = [
+  {
+    selector : 'node[label]',
+    style : {
+      'label' : 'data(label)',
+      'font-size' : '8pt',
+      'text-valign' : 'center',
+      'text-halign' : 'right',
+      'text-margin-x' : '4pt',
+      'color' : '#d3d3d3',
+    },
+  },
+  {
+    selector : 'node[group="org"]',
+    style : {
+      'background-color' : 'lightblue',
+    },
+  },
+  {
+    selector : 'node[group="sys"]',
+    style : {
+      'background-color' : 'yellow',
+    },
+  },
+  {
+    selector : 'node[group="fnc"]',
+    style : {
+      'background-color' : 'pink',
+    },
+  },
+  {
+    selector : 'node[group="ver"]',
+    style : {
+      'background-color' : 'olivegreen',
+    },
+  },
+  {
+    selector : 'node[group="arc"]',
+    style : {
+      'background-color' : 'violet',
+    },
+  },
+  {
+    selector : 'node[group="int"]',
+    style : {
+      'background-color' : 'cornflowerblue',
+    },
+  },
+  {
+    selector : 'edge',
+    style : {
+      'curve-style' : 'straight',
+      'width' : '2px',
+      'target-arrow-shape' : 'triangle-backcurve',
+    },
+  },
+];
+
+const level = {
+  'org' : 0,
+  'ucd' : 1,
+  'sys' : 3,
+  'fnc' : 4,
+  'int' : 5,
+  'pad' : 6,
+  'ver' : 7,
+  'doc' : 8
+};
+
+function draw(data) {
+  const visjs_options = {
+    nodes : {
+      shape : "dot",
+      font : {
+        color : "#ffffff",
+      },
+      borderWidth : 2,
+    },
+    edges : {
+      width : 2,
+    },
+  };
+
+  return new Network(document.getElementById('viewer'), data, visjs_options);
+}
+
+$(function() {
+  // Step 1: Compile the network graph from node and edge data.
+  const cy = cytoscape({
+    elements : data,
+    style : style,
+    layout : {
+      name : 'cose',
+    },
+  });
+
+  /* Step 2: If user wants to see a subset graph relevant to an specific
+  node_id, process the graph to select all predecessors and successors of
+  node_id. Eliminate others.
+
+  TODO(Antony): limit up to 6-th degree of separations
+  */
+  const selected_nodeid = urlQuery.id;
+  if (selected_nodeid) {
+    filterNodes(cy, '#' + selected_nodeid);
+  }
+
+  /* Step 3: Convert the graph the the Visjs compatible format. The Visjs
+  encodes edge metadata in the form of `from`, `to`, not `source`, `target`.
+  Also, Visjs encodes bi-directional parallel edges as one edge item, not two.
+  */
+
+  // Export nodes
+  const filtered_nodes = cy.nodes().map((ele) => {
+    var data = ele.data();
+
+    // Adjust gravity
+    const this_level = level[data.group];
+    data['level'] = this_level;
+
+    if (this_level == 1 || this_level >= 6) {
+      data['mass'] = 5;
+    }
+
+    return data;
+  });
+
+  // Export edges, omit bi-directional edges.
+  const filtered_edges = cy.edges('[^duplicate]').map((ele) => {
+    const data = ele.data();
+    var output_data = {from : data.source, to : data.target};
+    if ('arrows' in data) {
+      output_data['arrows'] = data.arrows;
+    }
+
+    return output_data;
+  });
+
+  /* Step 4: Visualize the selected graph; arrange the graph with COSE-like (aka
+  mass-spring interaction) layout. */
+  draw({nodes : filtered_nodes, edges : filtered_edges});
+});
+
+</script>
 </head>
 <body>
 <div id="viewer"></div>
@@ -91,18 +205,23 @@ $(function () {
 </html>
 </xsl:template>
 
-<xsl:template match="*">
+<xsl:template match="*">{group: 'nodes', data:
   {id: "<xsl:value-of select="@id"/>",
   label: "<xsl:value-of select="@id"/>: <xsl:value-of select="description/@brief"/>",
   group: "<xsl:value-of select="substring(@id,1,3)"/>",
-  },
+  <xsl:if test="name() = 'usecase' or name() = 'architecture'">
+	  physics: false,
+  </xsl:if>
+  }},
 </xsl:template>
 
-<xsl:template match="trace|test">
-  {from: "<xsl:value-of select="../@id"/>", to: "<xsl:value-of select="@ref"/>", arrows: 'to',},
+<xsl:template match="trace|test">{group: 'edges', data:
+  {source: "<xsl:value-of select="../@id"/>", target: "<xsl:value-of select="@ref"/>", arrows: 'to',}},
 </xsl:template>
 
-<xsl:template match="interface|function" mode="link">
-  {from: "<xsl:value-of select="@id"/>", to: "<xsl:value-of select="../@id"/>", arrows: 'from,to',},
+<xsl:template match="interface|function" mode="link">{group: 'edges', data:
+  {source: "<xsl:value-of select="@id"/>", target: "<xsl:value-of select="../@id"/>", arrows: 'from,to',}},
+{group: 'edges', data:
+  {target: "<xsl:value-of select="@id"/>", source: "<xsl:value-of select="../@id"/>", arrows: 'from,to', duplicate: true}},
 </xsl:template>
 </xsl:stylesheet>

--- a/stylesheets/originating_requirements.xsl
+++ b/stylesheets/originating_requirements.xsl
@@ -116,7 +116,7 @@ updated to ensure that they are coherent and traceable.</p>
 </xsl:template>
 
 <xsl:template match="orig">
-    <section>
+    <section data-format="markdown">
     <h2 id="{ @id }"><xsl:value-of select="@id"/>: <xsl:value-of select="description/@brief"/></h2>
     <xsl:value-of select="description"/>
 

--- a/stylesheets/physical_architecture.xsl
+++ b/stylesheets/physical_architecture.xsl
@@ -30,6 +30,10 @@ function renderPlantUML(config, document) {
     });
 }
 
+const localBiblio = {
+<xsl:apply-templates select="//document/reference"/>
+};
+
 const respecConfig = {
     specStatus: 'unofficial',
     additionalCopyrightHolders: '<xsl:value-of select="mbse/@copyright"/>',
@@ -38,6 +42,7 @@ const respecConfig = {
     alternateFormats: [
         {label: 'XML', uri: './main.xml'},
     ],
+    localBiblio: localBiblio,
 };
     </script>
   </head>
@@ -209,5 +214,14 @@ internal components of the system.</figcaption>
 
 <xsl:template match="this">
 <xsl:variable name="idref"><xsl:value-of select="@ref"/></xsl:variable>() "[<xsl:value-of select="@ref"/>] <xsl:value-of select="//*[@id=$idref]/description/@brief"/>"</xsl:template>
+
+<xsl:template match="reference">
+  <xsl:variable name="idref"><xsl:value-of select="translate(../@id, '-', '')"/></xsl:variable>
+<xsl:value-of select="$idref"/>: {
+  title: "<xsl:value-of select="../description/@brief"/>",
+  href: "<xsl:value-of select="@href"/>",
+  publisher: "<xsl:value-of select="@publisher"/>",
+},
+</xsl:template>
 
 </xsl:stylesheet>

--- a/stylesheets/physical_architecture.xsl
+++ b/stylesheets/physical_architecture.xsl
@@ -100,7 +100,10 @@ internal components of the system.</figcaption>
 
 <section id="tof"/>
 
-<xsl:apply-templates select="//architecture"/>
+  <xsl:for-each select="//architecture">
+      <xsl:sort select="substring-after(@id, '-')" data-type="number"/>
+      <xsl:apply-templates select="."/>
+  </xsl:for-each>
   </body>
   </html>
 </xsl:template>

--- a/stylesheets/product_requirements_specifications.xsl
+++ b/stylesheets/product_requirements_specifications.xsl
@@ -195,7 +195,7 @@ which in turn is verified by the Verification plans</figcaption>
   <section>
     <xsl:variable name="title"><xsl:value-of select="@id"/>: <xsl:value-of select="description/@brief"/></xsl:variable>
     <h2 id="{ @id }"><xsl:value-of select="$title"/></h2>
-    <div><xsl:apply-templates select="description"/></div>
+    <div data-format="markdown"><xsl:apply-templates select="description"/></div>
 
     <figure id="{ @id }-uml">
     <xsl:variable name="id"><xsl:value-of select="@id"/></xsl:variable>
@@ -211,7 +211,7 @@ which in turn is verified by the Verification plans</figcaption>
 
     <section>
     <h2 id="{ @id }"><xsl:value-of select="$title"/></h2>
-    <div><xsl:apply-templates select="description"/></div>
+    <div data-format="markdown"><xsl:apply-templates select="description"/></div>
 
     <p>Linked requirements:</p>
     <ul>


### PR DESCRIPTION
Given a query in `out/network.html?id=ucd-1`, select all requirements that are
predecessors and successors of item `ucd-1`. Visualize only those related
to the item.