### PR TITLE
Render IDEF-0 diagrams if exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ $(prefix)/graphml.xml:stylesheets/graphml.xsl $(main)
 
 $(main): $(sort $(wildcard $(model_path)/*/*.xml))
 	mkdir -p $(dir $(main))
-	echo '<mbse copyright="$(copyright)" plantuml_host="$(plantuml_host)">' > $@ &&\
+	echo '<mbse copyright="$(copyright)" plantuml_host="$(plantuml_host)" idef0svg_host="$(idef0svg_host)">' > $@ &&\
 	cat $^ >> $@ &&\
 	echo '</mbse>' >> $@
 

--- a/static/main.js
+++ b/static/main.js
@@ -21,6 +21,14 @@ function renderPlantUML(config, document) {
     });
 }
 
+function renderIDEF0(config, document) {
+    $('.idef0').each(function() {
+        const alt = $(this).text();
+        const src = idef0svg_host + window.plantumlEncoder.encode(alt);
+        $(this).replaceWith($('<img>').attr('src', src).attr('alt', alt));
+    });
+}
+
 function getRespecConfig(copyright_holder, local_biblio=null) {
     let config = {
             specStatus: 'unofficial',
@@ -32,7 +40,7 @@ function getRespecConfig(copyright_holder, local_biblio=null) {
         };
 
     if (local_biblio) {
-        config.preProcess = [renderPlantUML];
+        config.preProcess = [renderPlantUML, renderIDEF0];
         config.localBiblio = local_biblio;
     }
 

--- a/stylesheets/product_requirements_specifications.xsl
+++ b/stylesheets/product_requirements_specifications.xsl
@@ -20,6 +20,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <script src="../static/main.js"></script>
   <script class="remove">
 const plantuml_host = '<xsl:value-of select="mbse/@plantuml_host"/>/plantuml/svg/';
+const idef0svg_host = '<xsl:value-of select="mbse/@idef0svg_host"/>/svg/';
 
 const localBiblio = {
 <xsl:apply-templates select="//document/reference"/>
@@ -176,7 +177,7 @@ which in turn is verified by the Verification plans</figcaption>
 
     <figure id="{ @id }-uml">
     <xsl:variable name="id"><xsl:value-of select="@id"/></xsl:variable>
-    <xsl:apply-templates select="uml"/>
+    <xsl:apply-templates select="uml|idef0"/>
     </figure>
 
     <xsl:apply-templates select="function"/>
@@ -243,9 +244,25 @@ which in turn is verified by the Verification plans</figcaption>
     <figcaption>Activity diagram "<xsl:value-of select="$title"/>"</figcaption>
 </xsl:template>
 
+<xsl:template match="idef0">
+    <xsl:variable name="title"><xsl:value-of select="../@id"/>: <xsl:value-of select="../description/@brief"/></xsl:variable>
+    <pre class="idef0">
+    <xsl:apply-templates/>
+    </pre>
+
+    <figcaption>Flow diagram "<xsl:value-of select="$title"/>"</figcaption>
+</xsl:template>
+
 <xsl:template match="this">
   <xsl:variable name="idref"><xsl:value-of select="@ref"/></xsl:variable>
-<xsl:value-of select="@color"/>:[<xsl:value-of select="$idref"/>] <xsl:value-of select="//description[../@id=$idref]/@brief"/>;</xsl:template>
+<xsl:choose>
+<xsl:when test="name(..) = 'uml'">
+<xsl:value-of select="@color"/>:[<xsl:value-of select="$idref"/>] <xsl:value-of select="//description[../@id=$idref]/@brief"/>;</xsl:when>
+<!-- otherwise, idef0 diagram. -->
+<xsl:otherwise>
+[<xsl:value-of select="$idref"/>: <xsl:value-of select="//description[../@id=$idref]/@brief"/>]</xsl:otherwise>
+</xsl:choose>
+</xsl:template>
 
 <xsl:template match="trace|test">
     <xsl:variable name="idref"><xsl:value-of select="@ref"/></xsl:variable>


### PR DESCRIPTION
When the xml tag `<idef0>` is found, send the contents to a remote web server for rendering.

The textual notation of IDEF-0 diagram is supposed to be a DSL similar to
https://github.com/jimmyjazz/IDEF0-SVG

This PR does not implement the IDEF-0 parsing and figure generation web server. Please refer to https://github.com/antonysigma/IDEF0-SVG/tree/python-webapp for the reference implementation.