### PR TITLE
Group archtecture diagrams by Logical and Physical

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ model_path=example_model
 reports=$(prefix)/originating_requirements.html \
 	$(prefix)/use_cases.html \
 	$(prefix)/product_requirements_specifications.html \
-	$(prefix)/physical_architecture.html \
+	$(prefix)/logical_and_physical_architecture.html \
 	$(prefix)/network.html
 main=$(prefix)/main.xml
 copyright=

--- a/static/main.js
+++ b/static/main.js
@@ -15,7 +15,7 @@ function removeW3CWatermark(config, document) {
 
 function renderPlantUML(config, document) {
     $('.uml').each(function() {
-        const alt = $(this).text();
+        const alt = 'skin rose\n' + $(this).text();
         const src = plantuml_host + window.plantumlEncoder.encode(alt);
         $(this).replaceWith($('<img>').attr('src', src).attr('alt', alt));
     });

--- a/static/schema.rnc
+++ b/static/schema.rnc
@@ -96,7 +96,9 @@ idef0 = element idef0 { (text | this)* }
 this = element this { attlist.this, empty }
 
 # Optionally, specify the id of the child requirement.
-attlist.this &= attribute ref { xsd:IDREF }?
+attlist.this &=
+  attribute ref { xsd:IDREF }?,
+  [ a:defaultValue = "interface" ] attribute type { "interface" | "component" | "node" | "file" }?
 
 # Sections of the use case description, borrowed from Alistair Cockburn
 pre-condition = element pre-condition { text }
@@ -200,7 +202,8 @@ architecture =
 # status: initial or firm
 attlist.architecture &=
   id_attr,
-  status_attr
+  status_attr,
+  [ a:defaultValue = "false" ] attribute is_logical { "true" | "false" }?
 # Interface between two components of a system
 interface =
   element interface {

--- a/static/schema.rng
+++ b/static/schema.rng
@@ -241,6 +241,16 @@
         <data type="IDREF"/>
       </attribute>
     </optional>
+    <optional>
+      <attribute name="type" a:defaultValue="interface">
+        <choice>
+          <value>interface</value>
+          <value>component</value>
+          <value>node</value>
+          <value>file</value>
+        </choice>
+      </attribute>
+    </optional>
   </define>
   <!-- Sections of the use case description, borrowed from Alistair Cockburn -->
   <define name="pre-condition">
@@ -452,6 +462,14 @@
   <define name="attlist.architecture" combine="interleave">
     <ref name="id_attr"/>
     <ref name="status_attr"/>
+    <optional>
+      <attribute name="is_logical" a:defaultValue="false">
+        <choice>
+          <value>true</value>
+          <value>false</value>
+        </choice>
+      </attribute>
+    </optional>
   </define>
   <!-- Interface between two components of a system -->
   <define name="interface">

--- a/stylesheets/logical_and_physical_architecture.xsl
+++ b/stylesheets/logical_and_physical_architecture.xsl
@@ -8,7 +8,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:template match="/">
   <html>
   <head>
-  <title>Physical architecture and interfaces</title>
+  <title>Logical and physical architecture</title>
   <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"/>
 <script src="https://code.jquery.com/jquery.min.js"></script>
 <script src="https://cdn.rawgit.com/jmnote/plantuml-encoder/d133f316/dist/plantuml-encoder.min.js"></script>
@@ -19,15 +19,6 @@ const plantuml_host = '<xsl:value-of select="mbse/@plantuml_host"/>/plantuml/svg
 const local_biblio = {
 <xsl:apply-templates select="//document/reference"/>
 };
-
-function renderPlantUML(config, document) {
-    $('.uml').each(function() {
-        const alt = $(this).text();
-        const src = '<xsl:value-of select="mbse/@plantuml_host"/>/plantuml/svg/' +
-            window.plantumlEncoder.encode(alt);
-        $(this).replaceWith($('&lt;img>').attr('src', src).attr('alt', alt));
-    });
-}
 
 const respecConfig = getRespecConfig('<xsl:value-of select="mbse/@copyright"/>', local_biblio);
     </script>
@@ -74,6 +65,15 @@ document (such as a mechanical interface drawing, electrical pinout, firmware/so
 communication protocol, etc.).
 </p>
 
+<p>
+The Logical Architecture Diagram (LAD) groups the functions into sub-systems. Flows among
+functions are mapped to Interfaces, featuring interactions among sub-systems.
+
+The LAD is in turn implemented by physical components in the Physical Architecture Diagram (PAD).
+The PAD links all external interfaces with the corresponding
+internal components of the system.
+</p>
+
 <figure>
 <img src="../static/trace-requirements.png"/>
 <figcaption>Interface specifications are traced back to the Originating Requirements,
@@ -86,10 +86,28 @@ internal components of the system.</figcaption>
 
 <section id="tof"/>
 
-  <xsl:for-each select="//architecture">
+<section>
+  <h2>Logical architecture</h2>
+  <xsl:choose>
+  <xsl:when test="//architecture[@is_logical = 'true']">
+    <xsl:for-each select="//architecture[@is_logical = 'true']">
+        <xsl:sort select="substring-after(@id, '-')" data-type="number"/>
+        <xsl:apply-templates select="."/>
+    </xsl:for-each>
+  </xsl:when>
+  <xsl:otherwise>
+  <p>This section is intentionally left blank.</p>
+  </xsl:otherwise>
+  </xsl:choose>
+</section>
+
+<section>
+  <h2>Physical architecture</h2>
+  <xsl:for-each select="//architecture[not(@is_logical = 'true')]">
       <xsl:sort select="substring-after(@id, '-')" data-type="number"/>
       <xsl:apply-templates select="."/>
   </xsl:for-each>
+</section>
   </body>
   </html>
 </xsl:template>
@@ -202,7 +220,13 @@ internal components of the system.</figcaption>
 <xsl:template match="uml"><xsl:apply-templates/></xsl:template>
 
 <xsl:template match="this">
-<xsl:variable name="idref"><xsl:value-of select="@ref"/></xsl:variable>() "[<xsl:value-of select="@ref"/>] <xsl:value-of select="//*[@id=$idref]/description/@brief"/>"</xsl:template>
+<xsl:variable name="idref"><xsl:value-of select="@ref"/></xsl:variable>
+<xsl:variable name="label">"[<xsl:value-of select="@ref"/>] <xsl:value-of select="//*[@id=$idref]/description/@brief"/>"</xsl:variable>
+<xsl:choose>
+  <xsl:when test="not(@type)">() <xsl:value-of select="$label"/></xsl:when>
+  <xsl:otherwise><xsl:value-of select="@type"/><xsl:text> </xsl:text><xsl:value-of select="$label"/></xsl:otherwise>
+</xsl:choose>
+</xsl:template>
 
 <xsl:template match="reference">
   <xsl:variable name="idref"><xsl:value-of select="translate(../@id, '-', '')"/></xsl:variable>

--- a/stylesheets/network.xsl
+++ b/stylesheets/network.xsl
@@ -91,7 +91,7 @@ const style = [
     },
   },
   {
-    selector : 'node[group="arc"]',
+    selector : 'node[group="pad" || group="iad" || group="arc"]',
     style : {
       'background-color' : 'violet',
     },

--- a/stylesheets/originating_requirements.xsl
+++ b/stylesheets/originating_requirements.xsl
@@ -26,7 +26,7 @@ const respecConfig = getRespecConfig('<xsl:value-of select="mbse/@copyright"/>')
   <li>Originating requirements (this document)</li>
   <li><a href="use_cases.html">Use cases</a></li>
   <li><a href="product_requirements_specifications.html">Product requirements specification</a></li>
-  <li><a href="physical_architecture.html">Physical architecture and interfaces</a></li>
+  <li><a href="logical_and_physical_architecture.html">Physical architecture and interfaces</a></li>
   </ol>
 
   <p>The document catches all of the wish lists from all stackholders.
@@ -132,7 +132,7 @@ updated to ensure that they are coherent and traceable.</p>
 <b>[<a>
 <xsl:attribute name="href">
   <xsl:choose>
-    <xsl:when test="name(..) = 'interface'">./physical_architecture.html#</xsl:when>
+    <xsl:when test="name(..) = 'interface'">./logical_and_physical_architecture.html#</xsl:when>
     <xsl:when test="name(..) = 'usecase'">./use_cases.html#</xsl:when>
     <xsl:otherwise>./product_requirements_specifications.html#</xsl:otherwise>
   </xsl:choose>

--- a/stylesheets/product_requirements_specifications.xsl
+++ b/stylesheets/product_requirements_specifications.xsl
@@ -37,7 +37,7 @@ const respecConfig = getRespecConfig('<xsl:value-of select="mbse/@copyright"/>',
   <li><a href="originating_requirements.html">Originating requirements</a></li>
   <li><a href="use_cases.html">Use cases</a></li>
   <li>Product requirements specification (this document)</li>
-  <li><a href="physical_architecture.html">Physical architecture and interfaces</a></li>
+  <li><a href="logical_and_physical_architecture.html">Logical and physical architecture</a></li>
   </ol>
 
   <p>The document refines the high-level requirements into system-level specifications.
@@ -281,7 +281,7 @@ which in turn is verified by the Verification plans</figcaption>
 <xsl:template match="description" mode="link">
   <xsl:variable name="hash">
     <xsl:choose>
-      <xsl:when test="name(..) = 'interface'">./physical_architecture.html#</xsl:when>
+      <xsl:when test="name(..) = 'interface'">./logical_and_physical_architecture.html#</xsl:when>
       <xsl:when test="name(..) = 'usecase'">./use_cases.html#</xsl:when>
       <xsl:otherwise>#</xsl:otherwise>
     </xsl:choose>

--- a/stylesheets/use_cases.xsl
+++ b/stylesheets/use_cases.xsl
@@ -27,7 +27,7 @@ const respecConfig = getRespecConfig('<xsl:value-of select="mbse/@copyright"/>')
   <li><a href="originating_requirements.html">Originating requirements</a></li>
   <li>Use cases (this document)</li>
   <li><a href="product_requirements_specifications.html">Product requirements specification</a></li>
-  <li><a href="physical_architecture.html">Physical architecture and interfaces</a></li>
+  <li><a href="logical_and_physical_architecture.html">Logical and physical architecture</a></li>
   </ol>
 
   <p>The document captures the high-level use cases requested by the stakeholders.
@@ -127,7 +127,7 @@ Use cases helps capture missing high-level requirements.</figcaption>
 <b>[<a>
 <xsl:attribute name="href">
   <xsl:choose>
-    <xsl:when test="name(..) = 'interface'">./physical_architecture.html#</xsl:when>
+    <xsl:when test="name(..) = 'interface'">./logical_and_physical_architecture.html#</xsl:when>
     <xsl:when test="name(..) = 'usecase'">./use_cases.html#</xsl:when>
     <xsl:otherwise>./product_requirements_specifications.html#</xsl:otherwise>
   </xsl:choose>


### PR DESCRIPTION
Logical architecture is technology independent, which helps long term
projects (e.g. > 3 years) to map the design to new & promising
technologies.

Rename the document to "Logical and Physical architecture". Add an
attribute "is_logical for tag <architecture> . Print the diagrams under
separate sections: Logical Arch, and Physical Arch. Update the RelaxNG
schema accordingly.

Visualization: architecture nodes having ID prefix IAD, PAD, ARC should
be visualized in violet color.

PlantUML: Draw functional requirement as block or pipe. Draw components
as block, file, node, interface etc.