### PR TITLE
Highlight new programming languages

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+---
+Language: JavaScript
+BasedOnStyle:  Google
+
+ColumnLimit:     100
+IndentWidth:     4

--- a/static/main.js
+++ b/static/main.js
@@ -11,6 +11,7 @@ function changeCopyright(config, document) {
  */
 function removeW3CWatermark(config, document) {
     $('body').css('background', 'white');
+    $('.secno').css('color', '#ccc');
 }
 
 function renderPlantUML(config, document) {
@@ -29,16 +30,46 @@ function renderIDEF0(config, document) {
     });
 }
 
-function getRespecConfig(copyright_holder, local_biblio=null) {
+function getLangURL(lang) {
+    return `https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/es/languages/${lang}.min.js`;
+}
+
+async function loadLanguages() {
+    const [hljs_script, ini, python, sql] = await Promise.all([
+        import('https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/es/core.min.js'),
+        import(getLangURL('ini')),
+        import(getLangURL('python')),
+        import(getLangURL('sql')),
+    ]);
+
+    window.hljs = hljs_script.default;
+    hljs.registerLanguage('ini', ini.default);
+    hljs.registerLanguage('python', python.default);
+    hljs.registerLanguage('sql', sql.default);
+}
+
+function applyCustomLanguages() {
+    for (const e of document.querySelectorAll('.ini, .python, .sql')) {
+        window.hljs.highlightElement(e);
+    }
+}
+
+function getRespecConfig(copyright_holder, local_biblio = null) {
     let config = {
-            specStatus: 'unofficial',
-            additionalCopyrightHolders: copyright_holder,
-            preProcess: [renderPlantUML, renderIDEF0],
-            postProcess: [changeCopyright, removeW3CWatermark],
-            alternateFormats: [
-                {label: 'XML', uri: './main.xml'},
-            ],
-        };
+        specStatus: 'unofficial',
+        additionalCopyrightHolders: copyright_holder,
+        preProcess: [
+            renderPlantUML, renderIDEF0,
+            // loadLanguages
+        ],
+        postProcess: [
+            changeCopyright, removeW3CWatermark,
+            // applyCustomLanguages,
+        ],
+        alternateFormats: [
+            {label: 'XML', uri: './main.xml'},
+        ],
+    };
 
     if (local_biblio) {
         config.localBiblio = local_biblio;

--- a/static/schema.rnc
+++ b/static/schema.rnc
@@ -232,7 +232,9 @@ optical = element optical { text }
 # Software or firmware properties of the interface
 software = element software { text }
 document = element document { attlist.document, description, reference }
-attlist.document &= attribute id { ID }
+
+citation_id = xsd:ID { pattern = "\w+\d{4}" }
+attlist.document &= attribute id { citation_id }
 
 ########################################
 # Entry point

--- a/stylesheets/logical_and_physical_architecture.xsl
+++ b/stylesheets/logical_and_physical_architecture.xsl
@@ -139,7 +139,7 @@ internal components of the system.</figcaption>
 
     <section>
     <h2 id="{ $id }"><xsl:value-of select="$title"/></h2>
-    <div data-format="markdown"><xsl:value-of select="description"/></div>
+    <div data-format="markdown"><xsl:apply-templates select="description"/></div>
 
     <p>Satisfies:</p>
     <ul>
@@ -206,7 +206,7 @@ internal components of the system.</figcaption>
     </li>
 </xsl:template>
 
-<xsl:template match="mechanical|electrical|software">
+<xsl:template match="mechanical|electrical|software|optical">
 <li><xsl:value-of select="text()"/></li>
 </xsl:template>
 
@@ -228,6 +228,13 @@ internal components of the system.</figcaption>
   href: "<xsl:value-of select="@href"/>",
   publisher: "<xsl:value-of select="@publisher"/>",
 },
+</xsl:template>
+
+<xsl:template match="figure">
+  <figure>
+    <img src="{ @src }"/>
+    <figcaption><xsl:value-of select="."/></figcaption>
+  </figure>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/stylesheets/originating_requirements.xsl
+++ b/stylesheets/originating_requirements.xsl
@@ -54,8 +54,8 @@ items were selected to capture the behavior (use cases), constraints and perform
 requirements), and interfaces (interfaces) which are typically contained in input documentation.
 Each originating requirement is systematically considered, and then traced to relevant item(s).</p>
 
-<p>Some originating requirements are not traced to anything or are traced to an item that doesn’t
-exactly match – this is part of the requirements analysis process that determines which stakeholder
+<p>Some originating requirements are not traced to anything or are traced to an item that doesn't
+exactly match – this is part of the requirement analysis process that determines which stakeholder
 requirements take precedence, and which will not be included in the current project. During this
 process, the lower level items do not need to be fully defined – that will occur in the next phase – in
 some cases a placeholder for further definition is sufficient.</p>

--- a/stylesheets/product_requirements_specifications.xsl
+++ b/stylesheets/product_requirements_specifications.xsl
@@ -14,7 +14,6 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"/>
   <script src="https://code.jquery.com/jquery.min.js"></script>
   <script src="https://cdn.rawgit.com/jmnote/plantuml-encoder/d133f316/dist/plantuml-encoder.min.js"></script>
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script id="MathJax-script" async="async" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   <script src="https://github.com/tabatkins/railroad-diagrams/raw/gh-pages/railroad.js"></script>
   <script src="../static/main.js"></script>
@@ -144,7 +143,7 @@ which in turn is verified by the Verification plans</figcaption>
 
 <xsl:template match="constraint|performance">
     <xsl:variable name="id"><xsl:value-of select="@id"/></xsl:variable>
-    <section data-format="markdown">
+    <section>
     <h2 id="{ $id }"><xsl:value-of select="$id"/>: <xsl:value-of select="description/@brief"/></h2>
 
     <ul>
@@ -152,10 +151,10 @@ which in turn is verified by the Verification plans</figcaption>
     <li><b>Discipline: </b> <xsl:value-of select="categories/@discipline"/></li>
     </ul>
 
-    <div><xsl:apply-templates select="description"/></div>
+    <div data-format="markdown"><xsl:apply-templates select="description"/></div>
 
     <xsl:if test="rationale/text() != ''">
-    <p><b>Rationale:</b> <xsl:value-of select="rationale"/></p>
+    <p><b>Rationale: </b><xsl:value-of select="rationale"/></p>
     </xsl:if>
 
     <p>Satisfies:</p>
@@ -205,6 +204,8 @@ which in turn is verified by the Verification plans</figcaption>
       <xsl:variable name="id_descendent"><xsl:value-of select="@ref"/></xsl:variable>
       <xsl:apply-templates select="//behavior[@id=$id_descendent]/function/satisfies"/>
     </xsl:for-each>
+    <xsl:variable name="this_id"><xsl:value-of select="@id"/></xsl:variable>
+    <xsl:apply-templates select="//*[satisfies/@ref=$this_id]/description" mode="link"/>
     </ul>
     </section>
 </xsl:template>
@@ -213,7 +214,7 @@ which in turn is verified by the Verification plans</figcaption>
     <xsl:variable name="id"><xsl:value-of select="@id"/></xsl:variable>
     <xsl:variable name="title"><xsl:value-of select="@id"/>: <xsl:value-of select="description/@brief"/></xsl:variable>
 
-    <section data-format="markdown">
+    <section>
     <h2 id="{ @id }"><xsl:value-of select="$title"/></h2>
 
     <ul>
@@ -221,7 +222,7 @@ which in turn is verified by the Verification plans</figcaption>
     <li><b>Discipline: </b> <xsl:value-of select="categories/@discipline"/></li>
     </ul>
 
-    <div><xsl:apply-templates select="description"/></div>
+    <div data-format="markdown"><xsl:apply-templates select="description"/></div>
 
     <p>Linked requirements:</p>
     <ul>
@@ -289,13 +290,14 @@ which in turn is verified by the Verification plans</figcaption>
     <xsl:choose>
       <xsl:when test="name(..) = 'interface'">./logical_and_physical_architecture.html#</xsl:when>
       <xsl:when test="name(..) = 'usecase'">./use_cases.html#</xsl:when>
+      <xsl:when test="name(..) = 'orig'">./originating_requirements.html#</xsl:when>
       <xsl:otherwise>#</xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
 
     <li><b>
 <xsl:choose>
-  <xsl:when test="../reference">
+  <xsl:when test="name(..) != 'orig' and ../reference">
     <!-- External document reference -->
     [[<xsl:value-of select="translate(../@id, '-', '')"/>]]
   </xsl:when>
@@ -304,8 +306,8 @@ which in turn is verified by the Verification plans</figcaption>
     [<a href="{ concat($hash, ../@id) }"><xsl:value-of select="../@id"/></a>]
   </xsl:otherwise>
 </xsl:choose>
-<xsl:value-of select="@brief"/>:</b>
-<xsl:value-of select="text()"/>
+<xsl:value-of select="@brief"/>: </b>
+<xsl:value-of select="substring(translate(text(), '&#xA;', ' '), 1, 250)"/>...
     </li>
 </xsl:template>
 

--- a/stylesheets/use_cases.xsl
+++ b/stylesheets/use_cases.xsl
@@ -127,7 +127,7 @@ Use cases helps capture missing high-level requirements.</figcaption>
 </xsl:template>
 
 <xsl:template match="description" mode="link">
-<b>[<a>
+<li><b>[<a>
 <xsl:attribute name="href">
   <xsl:choose>
     <xsl:when test="name(..) = 'interface'">./logical_and_physical_architecture.html#</xsl:when>
@@ -138,7 +138,7 @@ Use cases helps capture missing high-level requirements.</figcaption>
   <xsl:value-of select="../@id"/>
 </xsl:attribute>
 <xsl:value-of select="../@id"/></a>] <xsl:value-of select="@brief"/>:</b>
-<xsl:value-of select="text()"/>
+<xsl:value-of select="text()"/></li>
 </xsl:template>
 
 <xsl:template match="pre-condition|main-event|post-condition|alternate-event">
@@ -146,6 +146,13 @@ Use cases helps capture missing high-level requirements.</figcaption>
 </xsl:template>
 
 <xsl:template match="description"><xsl:apply-templates/></xsl:template>
+
+<xsl:template match="figure">
+  <figure>
+    <img src="{ @src }"/>
+    <figcaption><xsl:value-of select="."/></figcaption>
+  </figure>
+</xsl:template>
 
 <xsl:template match="aside">
   <aside class="{ @class }"><xsl:value-of select="."/></aside>


### PR DESCRIPTION
Bypass Respec's default language rendering library. Download the recommended version of the `hljs` module. Given a hardcoded list of languages `ini`, `python`, `sql`, highlight the syntax.

Relax the supplementary document citation format. In the logical/physical architecture document output, also include optical specifications. Embed user figures.

In the originating requirement doc, remove `polyfill.js`. Render the markdown formatted text only for the `<description/>` tag.

In the product requirement specification document, permit the hyperlinks to the originating requirements. Summarize the linked requirements to no more than 250 characters.

In the Use Cases document, embed user figures. Render linked requirements as bullet points.

Render section number texts in pale gray color to defocus them.