### PR TITLE
Move common transform templates to separate file

### DIFF
--- a/stylesheets/common.xsl
+++ b/stylesheets/common.xsl
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:template match="reference">
+  <xsl:variable name="idref"><xsl:value-of select="translate(../@id, '-', '')"/></xsl:variable>
+<xsl:value-of select="$idref"/>: {
+  title: "<xsl:value-of select="../description/@brief"/>",
+  href: "<xsl:value-of select="@href"/>",
+  publisher: "<xsl:value-of select="@publisher"/>",
+},
+</xsl:template>
+
+<xsl:template match="/" mode="scripts">
+  <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"/>
+  <script src="https://code.jquery.com/jquery.min.js"></script>
+  <script src="https://cdn.rawgit.com/jmnote/plantuml-encoder/d133f316/dist/plantuml-encoder.min.js"></script>
+  <script src="../static/main.js"></script>
+  <script class="remove">
+const plantuml_host = '<xsl:value-of select="mbse/@plantuml_host"/>/plantuml/svg/';
+const idef0svg_host = '<xsl:value-of select="mbse/@idef0svg_host"/>/svg/';
+
+const localBiblio = {
+<xsl:apply-templates select="//document/reference"/>
+};
+
+const respecConfig = getRespecConfig('<xsl:value-of select="mbse/@copyright"/>', localBiblio);
+    </script>
+</xsl:template>
+
+<xsl:template match="description" mode="link">
+  <xsl:variable name="hash">
+    <xsl:choose>
+      <xsl:when test="name(..) = 'interface'">./logical_and_physical_architecture.html#</xsl:when>
+      <xsl:when test="name(..) = 'usecase'">./use_cases.html#</xsl:when>
+      <xsl:when test="name(..) = 'orig'">./originating_requirements.html#</xsl:when>
+      <xsl:otherwise>./product_requirements_specifications.html#</xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+
+    <li><b>
+<xsl:choose>
+  <xsl:when test="name(..) = 'document'">
+    <!-- External document reference -->
+    [[<xsl:value-of select="translate(../@id, '-', '')"/>]]
+  </xsl:when>
+  <xsl:otherwise>
+    <!-- Cross-reference -->
+    [<a href="{ concat($hash, ../@id) }"><xsl:value-of select="../@id"/></a>]
+  </xsl:otherwise>
+</xsl:choose>
+<xsl:value-of select="@brief"/>:</b>
+<xsl:value-of select="text()"/>
+    </li>
+</xsl:template>
+
+<xsl:template match="uml">
+  <xsl:param name="diagram_type"/>
+  <figure id="{ ../@id }-uml">
+    <pre class="uml"><xsl:apply-templates/></pre>
+    <figcaption><xsl:value-of select="$diagram_type"/> diagram "<xsl:value-of select="../@id"/>: <xsl:value-of select="../description/@brief"/>"</figcaption>
+  </figure>
+</xsl:template>
+
+<xsl:template match="aside">
+  <aside class="{ @class }"><xsl:value-of select="."/></aside>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/stylesheets/logical_and_physical_architecture.xsl
+++ b/stylesheets/logical_and_physical_architecture.xsl
@@ -3,25 +3,14 @@
 <xsl:stylesheet version="1.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
+<xsl:include href="common.xsl" />
 <xsl:output method="html" indent="yes" />
 
 <xsl:template match="/">
   <html>
   <head>
   <title>Logical and physical architecture</title>
-  <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"/>
-<script src="https://code.jquery.com/jquery.min.js"></script>
-<script src="https://cdn.rawgit.com/jmnote/plantuml-encoder/d133f316/dist/plantuml-encoder.min.js"></script>
-<script src="../static/main.js"></script>
-  <script class="remove">
-const plantuml_host = '<xsl:value-of select="mbse/@plantuml_host"/>/plantuml/svg/';
-
-const local_biblio = {
-<xsl:apply-templates select="//document/reference"/>
-};
-
-const respecConfig = getRespecConfig('<xsl:value-of select="mbse/@copyright"/>', local_biblio);
-    </script>
+  <xsl:apply-templates select="." mode="scripts"/>
   </head>
   <body>
   <section id="abstract">
@@ -119,14 +108,9 @@ internal components of the system.</figcaption>
     <h2 id="{ @id }"><xsl:value-of select="$title"/></h2>
     <div data-format="markdown"><xsl:value-of select="description"/></div>
 
-    <figure id="{ @id }-uml">
-
-    <pre class="uml">
-    <xsl:apply-templates select="uml"/>
-    </pre>
-
-    <figcaption>Component diagram "<xsl:value-of select="$title"/>"</figcaption>
-    </figure>
+    <xsl:apply-templates select="uml">
+      <xsl:with-param name="diagram_type">Component</xsl:with-param>
+    </xsl:apply-templates>
 
     <xsl:apply-templates select="interface"/>
 
@@ -210,8 +194,6 @@ internal components of the system.</figcaption>
 <li><xsl:value-of select="text()"/></li>
 </xsl:template>
 
-<xsl:template match="uml"><xsl:apply-templates/></xsl:template>
-
 <xsl:template match="this">
 <xsl:variable name="idref"><xsl:value-of select="@ref"/></xsl:variable>
 <xsl:variable name="label">"[<xsl:value-of select="@ref"/>] <xsl:value-of select="//*[@id=$idref]/description/@brief"/>"</xsl:variable>
@@ -219,15 +201,6 @@ internal components of the system.</figcaption>
   <xsl:when test="not(@type)">() <xsl:value-of select="$label"/></xsl:when>
   <xsl:otherwise><xsl:value-of select="@type"/><xsl:text> </xsl:text><xsl:value-of select="$label"/></xsl:otherwise>
 </xsl:choose>
-</xsl:template>
-
-<xsl:template match="reference">
-  <xsl:variable name="idref"><xsl:value-of select="translate(../@id, '-', '')"/></xsl:variable>
-<xsl:value-of select="$idref"/>: {
-  title: "<xsl:value-of select="../description/@brief"/>",
-  href: "<xsl:value-of select="@href"/>",
-  publisher: "<xsl:value-of select="@publisher"/>",
-},
 </xsl:template>
 
 <xsl:template match="figure">

--- a/stylesheets/originating_requirements.xsl
+++ b/stylesheets/originating_requirements.xsl
@@ -3,6 +3,7 @@
 <xsl:stylesheet version="1.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
+<xsl:include href="common.xsl"/>
 <xsl:output method="html" indent="yes" />
 
 <xsl:key name="group_id" match="reference" use="@stakeholder" />
@@ -13,10 +14,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <title>Originating requirements</title>
   <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"/>
   <script src="https://code.jquery.com/jquery.min.js"></script>
-  <script src="../static/main.js"></script>
-  <script class="remove">
-const respecConfig = getRespecConfig('<xsl:value-of select="mbse/@copyright"/>');
-    </script>
+  <xsl:apply-templates select="." mode="scripts"/>
   </head>
   <body>
   <section id="abstract">
@@ -125,31 +123,6 @@ updated to ensure that they are coherent and traceable.</p>
 <xsl:template match="trace">
     <xsl:variable name="idref"><xsl:value-of select="@ref"/></xsl:variable>
     <xsl:apply-templates select="//description[../@id=$idref]" mode="link"/>
-</xsl:template>
-
-<xsl:template match="description" mode="link">
-    <li>
-<b>[<a>
-<xsl:attribute name="href">
-  <xsl:choose>
-    <xsl:when test="name(..) = 'interface'">./logical_and_physical_architecture.html#</xsl:when>
-    <xsl:when test="name(..) = 'usecase'">./use_cases.html#</xsl:when>
-    <xsl:otherwise>./product_requirements_specifications.html#</xsl:otherwise>
-  </xsl:choose>
-  <xsl:value-of select="../@id"/>
-</xsl:attribute>
-<xsl:value-of select="../@id"/></a>] <xsl:value-of select="@brief"/>:</b>
-<xsl:value-of select="text()"/>
-    </li>
-</xsl:template>
-
-<xsl:template match="reference">
-  <xsl:variable name="idref"><xsl:value-of select="translate(../@id, '-', '')"/>_external</xsl:variable>
-<xsl:value-of select="$idref"/>: {
-  title: "<xsl:value-of select="../description/@brief"/>",
-  href: "<xsl:value-of select="@href"/>",
-  publisher: "<xsl:value-of select="@stakeholder"/>",
-},
 </xsl:template>
 
 </xsl:stylesheet>

--- a/stylesheets/product_requirements_specifications.xsl
+++ b/stylesheets/product_requirements_specifications.xsl
@@ -3,6 +3,8 @@
 <xsl:stylesheet version="1.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
+<xsl:include href="common.xsl"/>
+
 <xsl:output method="html" indent="yes" />
 <xsl:key name="group_id" match="//categories" use="@group"/>
 
@@ -11,22 +13,9 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <head>
   <title>Product requirements specification</title>
   <link rel="stylesheet" href="https://github.com/tabatkins/railroad-diagrams/raw/gh-pages/railroad.css"/>
-  <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"/>
-  <script src="https://code.jquery.com/jquery.min.js"></script>
-  <script src="https://cdn.rawgit.com/jmnote/plantuml-encoder/d133f316/dist/plantuml-encoder.min.js"></script>
-  <script id="MathJax-script" async="async" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   <script src="https://github.com/tabatkins/railroad-diagrams/raw/gh-pages/railroad.js"></script>
-  <script src="../static/main.js"></script>
-  <script class="remove">
-const plantuml_host = '<xsl:value-of select="mbse/@plantuml_host"/>/plantuml/svg/';
-const idef0svg_host = '<xsl:value-of select="mbse/@idef0svg_host"/>/svg/';
-
-const localBiblio = {
-<xsl:apply-templates select="//document/reference"/>
-};
-
-const respecConfig = getRespecConfig('<xsl:value-of select="mbse/@copyright"/>', localBiblio);
-    </script>
+  <script id="MathJax-script" async="async" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  <xsl:apply-templates select="." mode="scripts"/>
   </head>
   <body>
   <section id="abstract">
@@ -182,7 +171,10 @@ which in turn is verified by the Verification plans</figcaption>
 
     <figure id="{ @id }-uml">
     <xsl:variable name="id"><xsl:value-of select="@id"/></xsl:variable>
-    <xsl:apply-templates select="uml|idef0"/>
+    <xsl:apply-templates select="uml">
+      <xsl:with-param name="diagram_type">Activity</xsl:with-param>
+    </xsl:apply-templates>
+    <xsl:apply-templates select="idef0"/>
     </figure>
 
     <xsl:apply-templates select="function"/>
@@ -231,24 +223,11 @@ which in turn is verified by the Verification plans</figcaption>
     </section>
 </xsl:template>
 
-<xsl:template match="aside">
-  <aside class="{ @class }"><xsl:value-of select="."/></aside>
-</xsl:template>
-
 <xsl:template match="figure">
   <figure>
     <img src="{ @src }"/>
     <figcaption><xsl:value-of select="."/></figcaption>
   </figure>
-</xsl:template>
-
-<xsl:template match="uml">
-    <xsl:variable name="title"><xsl:value-of select="../@id"/>: <xsl:value-of select="../description/@brief"/></xsl:variable>
-    <pre class="uml">
-    <xsl:apply-templates/>
-    </pre>
-
-    <figcaption>Activity diagram "<xsl:value-of select="$title"/>"</figcaption>
 </xsl:template>
 
 <xsl:template match="idef0">
@@ -274,15 +253,6 @@ which in turn is verified by the Verification plans</figcaption>
 <xsl:template match="satisfies|test">
     <xsl:variable name="idref"><xsl:value-of select="@ref"/></xsl:variable>
     <xsl:apply-templates select="//description[../@id=$idref]" mode="link"/>
-</xsl:template>
-
-<xsl:template match="reference">
-  <xsl:variable name="idref"><xsl:value-of select="translate(../@id, '-', '')"/></xsl:variable>
-<xsl:value-of select="$idref"/>: {
-  title: "<xsl:value-of select="../description/@brief"/>",
-  href: "<xsl:value-of select="@href"/>",
-  publisher: "<xsl:value-of select="@publisher"/>",
-},
 </xsl:template>
 
 <xsl:template match="description" mode="link">

--- a/stylesheets/use_cases.xsl
+++ b/stylesheets/use_cases.xsl
@@ -3,21 +3,14 @@
 <xsl:stylesheet version="1.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
+<xsl:include href="common.xsl"/>
 <xsl:output method="html" indent="yes" />
 
 <xsl:template match="/">
   <html>
   <head>
   <title>Use cases</title>
-  <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"/>
-<script src="https://code.jquery.com/jquery.min.js"></script>
-<script src="https://cdn.rawgit.com/jmnote/plantuml-encoder/d133f316/dist/plantuml-encoder.min.js"></script>
-<script src="../static/main.js"></script>
-  <script class="remove">
-const plantuml_host = '<xsl:value-of select="mbse/@plantuml_host"/>/plantuml/svg/';
-
-const respecConfig = getRespecConfig('<xsl:value-of select="mbse/@copyright"/>');
-    </script>
+  <xsl:apply-templates select="." mode="scripts"/>
   </head>
   <body>
   <section id="abstract">
@@ -71,14 +64,9 @@ Use cases helps capture missing high-level requirements.</figcaption>
     <h2 id="{ @id }"><xsl:value-of select="$title"/></h2>
     <div data-format="markdown"><xsl:apply-templates select="description"/></div>
 
-    <figure id="{ @id-uml }">
-
-    <pre class="uml">
-    <xsl:apply-templates select="uml"/>
-    </pre>
-
-    <figcaption>Use case "<xsl:value-of select="$title"/>"</figcaption>
-    </figure>
+    <xsl:apply-templates select="uml">
+      <xsl:with-param name="diagram_type">Use case</xsl:with-param>
+    </xsl:apply-templates>
 
     <section>
     <h2 id="{ @id }-pre-conditions">Pre-conditions</h2>
@@ -153,12 +141,6 @@ Use cases helps capture missing high-level requirements.</figcaption>
     <figcaption><xsl:value-of select="."/></figcaption>
   </figure>
 </xsl:template>
-
-<xsl:template match="aside">
-  <aside class="{ @class }"><xsl:value-of select="."/></aside>
-</xsl:template>
-
-<xsl:template match="uml"><xsl:apply-templates/></xsl:template>
 
 <xsl:template match="this">(<xsl:value-of select="../../@id"/>: <xsl:value-of select="../../description/@brief"/>)</xsl:template>
 


### PR DESCRIPTION
Move the templates `reference`, `satisfies`, `uml`, and `aside` to a separate file `common.xsl`. Also move the common main script tags to the common.xsl