### PR TITLE
Remove jQuery from requirement traceability analysis tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "cytoscape": "^3.30.2",
     "highlight.js": "^11.11.1",
-    "jquery": "^3.7.1",
     "marked": "^15.0.7",
     "plantuml-encoder": "^1.4.0",
     "split-grid": "^1.0.11",

--- a/src/network-main.ts
+++ b/src/network-main.ts
@@ -1,7 +1,6 @@
 import './network-main.css';
 
 import cytoscape from 'cytoscape';
-import $ from 'jquery';
 import {marked} from 'marked';
 import {encode as plantumlEncode} from 'plantuml-encoder';
 import Split from 'split-grid';
@@ -32,6 +31,39 @@ type network_t =
         nodes: node_t[],
         edges: edge_t[],
     }
+
+function setLink(targetId: string, href: string, text: string) {
+    const link = document.getElementById(targetId);
+    if (!link) {
+        return;
+    }
+
+    link.href = href;
+    link.textContent = text;
+}
+
+function setPanelSource(panelId: string, src: string) {
+    const panel = document.querySelector<HTMLIFrameElement>(panelId);
+    if (!panel) {
+        return;
+    }
+
+    panel.src = src;
+}
+
+function showRequirement(nodeId: string) {
+    const requirementPanel = document.getElementById('requirement');
+    if (!requirementPanel) {
+        return;
+    }
+
+    for (const child of requirementPanel.querySelectorAll('div')) {
+        child.classList.add('hidden');
+    }
+
+    const requirement = document.getElementById(nodeId);
+    requirement?.classList.remove('hidden');
+}
 
 function filterNodes(cy: cytoscape, id: string) {
     const selected = cy.$(id);
@@ -246,7 +278,7 @@ function setupNetwork(data: network_t, plantuml_host: string, idef0svg_host: str
         if (params.nodes.length === 1) {
             const node_id = filtered_nodes.get(params.nodes[0]).id;
             const url = `${findReferenceDoc(node_id)}#${node_id}`;
-            $('#source_doc').attr('href', './' + url).text(url);
+            setLink('source_doc', './' + url, url);
 
             var panel_id = '';
             switch (node_id.slice(0, 3)) {
@@ -263,35 +295,34 @@ function setupNetwork(data: network_t, plantuml_host: string, idef0svg_host: str
             }
 
             if (panel_id === '#requirement') {
-                $('#requirement div').addClass('hidden');
-                $('#' + node_id).removeClass('hidden');
+                showRequirement(node_id);
                 return;
             }
 
-            const plantuml_node = $('#' + node_id);
-            if (plantuml_node.length == 0) {
+            const plantuml_node = document.getElementById<HTMLElement>(node_id);
+            if (!plantuml_node) {
                 return;
             }
-            const is_plantuml = plantuml_node.parent('#uml').length;
+            const is_plantuml = plantuml_node.parentElement?.id === 'uml';
 
             if (is_plantuml) {
                 const plantuml_url =
-                    plantuml_host + plantumlEncode('skin rose\n' + plantuml_node.text());
-                $(panel_id).attr('src', plantuml_url);
+                    plantuml_host + plantumlEncode('skin rose\n' + plantuml_node.textContent);
+                setPanelSource(panel_id, plantuml_url);
                 return;
             }
 
             // else idef0
             const idef02svg_url =
-                idef0svg_host + plantumlEncode('skin rose\n' + plantuml_node.text());
-            $(panel_id).attr('src', idef02svg_url);
+                idef0svg_host + plantumlEncode('skin rose\n' + plantuml_node.textContent);
+            setPanelSource(panel_id, idef02svg_url);
         }
     });
 }
 
-$(() => {
+document.addEventListener('DOMContentLoaded', () => {
     // Render markdown text
-    for (let el of document.getElementsByClassName('markdown')) {
+    for (const el of document.getElementsByClassName('markdown')) {
         const markdown_text = el.innerText;
         el.innerHTML = marked.parse(markdown_text);
     }

--- a/stylesheets/originating_requirements.xsl
+++ b/stylesheets/originating_requirements.xsl
@@ -13,7 +13,6 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <head>
   <title>Originating requirements</title>
   <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"/>
-  <script src="https://code.jquery.com/jquery.min.js"></script>
   <xsl:apply-templates select="." mode="scripts"/>
   </head>
   <body>


### PR DESCRIPTION
jQuery is used narrowly for DOM manpulations, which is already covered by native ES6 APIs. Refactor the code base to remove jQuery dependencies.

Also remove the explicit download of jquery from the Originating requirement document.