### PR TITLE
Improve CI test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,3 +22,11 @@ jobs:
       - run:
           name: Validate MBSE model
           command: make validate
+
+      - run:
+          name: Validate MBSE model (clock-radio)
+          command: make validate model_path=advanced_examples/clock-radio-capella/ -Bj
+
+      - run:
+          name: Validate MBSE model (drone)
+          command: make validate model_path=advanced_examples/drone-doorstep/ -Bj


### PR DESCRIPTION
Other than validating the small-scaled model `phone-charger` at `example_model/`, also validate two other more complex system models:

- `advanced_examples/clock-radio-capella/`;
- `advanced_examples/drone-doorstep/`.

Re-enable the CircleCI service. Use a smaller Docker image to speed up CI server bootstrapping.