### PR TITLE
Request for comments: Offline functional & architectural diagrams

### DIFF
--- a/scripts/plantuml_decoder.py
+++ b/scripts/plantuml_decoder.py
@@ -1,0 +1,63 @@
+# Forked from https://gist.github.com/dyno/94ef6bb9644a88d6981d6a1a9eb70802
+# https://plantuml.com/text-encoding
+# https://github.com/dougn/python-plantuml/blob/master/plantuml.py#L64
+
+import base64
+import string
+import zlib
+
+plantuml_alphabet = (
+    string.digits + string.ascii_uppercase + string.ascii_lowercase + "-_"
+)
+base64_alphabet = string.ascii_uppercase + string.ascii_lowercase + string.digits + "+/"
+b64_to_plantuml = bytes.maketrans(
+    base64_alphabet.encode("utf-8"), plantuml_alphabet.encode("utf-8")
+)
+plantuml_to_b64 = bytes.maketrans(
+    plantuml_alphabet.encode("utf-8"), base64_alphabet.encode("utf-8")
+)
+
+
+def plantuml_encode(plantuml_text):
+    """zlib compress the plantuml text and encode it for the plantuml server"""
+    zlibbed_str = zlib.compress(plantuml_text.encode("utf-8"))
+    compressed_string = zlibbed_str[2:-4]
+    return (
+        base64.b64encode(compressed_string).translate(b64_to_plantuml).decode("utf-8")
+    )
+
+
+def plantuml_decode(plantuml_url):
+    """decode plantuml encoded url back to plantuml text"""
+    data = base64.b64decode(plantuml_url.translate(plantuml_to_b64).encode("utf-8"))
+    dec = zlib.decompressobj()  # without check the crc.
+    header = b"x\x9c"
+    return dec.decompress(header + data).decode("utf-8")
+
+
+if __name__ == "__main__":
+    # Poorman's unit testing procedure
+
+    url = "SyfFKj2rKt3CoKnELR1Io4ZDoSa700=="
+    decoded = plantuml_decode(url)
+
+    print(decoded)
+    print(plantuml_encode(decoded))
+    assert decoded == "Bob -> Alice : hello"
+
+    print(
+        plantuml_encode("""Cook Pizza receives Ingredients
+Cook Pizza respects Customer Order
+Cook Pizza respects Recipe
+Cook Pizza requires Chef
+Cook Pizza requires Kitchen
+Cook Pizza produces Pizza
+Take Order produces Customer Order
+Take Order respects Menu
+Take Order requires Wait Staff
+Eat Pizza receives Pizza
+Eat Pizza receives Hungry Customer
+Eat Pizza produces Satisfied Customer
+Eat Pizza produces Mess
+""")
+    )

--- a/scripts/to_offline.py
+++ b/scripts/to_offline.py
@@ -1,0 +1,83 @@
+import sys
+from xml.etree import ElementTree as etree
+
+import requests
+from plantuml_decoder import plantuml_encode
+
+
+def get_svg(url: str):
+    """Initiate the HTTP GET request given the URL string."""
+    try:
+        response = requests.get(url)
+        response.raise_for_status()  # Raise an error for bad responses
+
+        # Check if the response content type is SVG
+        if "image/svg+xml" in response.headers.get("Content-Type", ""):
+            svg_payload = response.text
+            return svg_payload
+        else:
+            print("The content is not SVG.")
+            return None
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching URL: {e}")
+        return None
+
+
+def replace_element(parent, elem, new_elem):
+    """A convenience function to replace XML tag <a> with <b> ."""
+    parent_index = list(parent).index(elem)
+    parent.remove(elem)
+    parent.insert(parent_index, new_elem)
+
+
+def download_svg(dom, class_name: str, port: int):
+    """Given an XML document representing a static HTML page, find all `<code
+    class="uml">`. Extract the contents in PlantUML language, and then invoke
+    the WebAPI to render the static SVG figure. Replace the `<code>` tag with
+    `<img src="" alt=""/>` embedding the SVG figure."""
+
+    parent_map = {c: p for p in dom.iter() for c in p}
+
+    # Get all elements with attribute class='uml'
+    for element in dom.findall(f'.//*[@class="{class_name}"]'):
+        # Replace the text of the element with an empty <svg> tag
+        if element.text is None:
+            continue
+
+        encoded = plantuml_encode(
+            f"skin rose\n{element.text}" if class_name == "uml" else element.text
+        )
+        url = f"http://localhost:{port}/svg/{encoded}"
+        svg_payload = get_svg(url)
+
+        svg_element = etree.fromstring(svg_payload)
+        parent = parent_map[element]
+        replace_element(parent, element, svg_element)
+
+    return dom
+
+
+def remove_namespace(doc, namespace):
+    """Remove namespace in the passed document in place."""
+    ns = "{%s}" % namespace
+    nsl = len(ns)
+    for elem in doc.iter():
+        if elem.tag.startswith(ns):
+            elem.tag = elem.tag[nsl:]
+
+
+if __name__ == "__main__":
+    # Example usage
+    if len(sys.argv) < 2:
+        print(f"Usage: python {sys.argv[0]} path/to/xml")
+        exit()
+
+    # Load the XML file
+    dom = etree.parse(sys.argv[1])
+
+    dom = download_svg(dom, class_name="uml", port=8080)
+    dom = download_svg(dom, class_name="idef0", port=5000)
+    remove_namespace(dom, "http://www.w3.org/2000/svg")
+
+    # Return or save the modified DOM as a string
+    dom.write(sys.argv[1], encoding="utf-8", method="html")


### PR DESCRIPTION
Sometimes, the company network does not permit on-the-premises hosting of PlantUML and IDEF0 rendering web servers. Draft a script to scan all generated XML files representing the product requirement specification documents, and then pre-load and embed all rendered functional (IDEF0), use-cases, and architecture diagrams (PlantUML) as static offline figures.

Todo items:

- [ ] Not everyone knows how to install Python. Perhaps Perl script?
- [ ] Separation of concern: This script should belong to the [IDEF0/PlantUML rendering server repo](https://github.com/antonysigma/IDEF0-SVG), in which the Python language acts as the "glue code" integrating PlantUML (in Java), and IDEF0 (in Ruby), and XML processing (in Python).

Related to: #20 