### PR TITLE
Force strict XHTML1.0 output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ vis:$(prefix)/network.html
 watch: | static/plantuml.jar
 	java -jar static/plantuml.jar -picoweb:8000 & \
 	while true; do \
-		inotifywait -e modify,create,delete -r model/ && \
+		inotifywait -e modify,create,delete -r $(model_path)/ && \
 			sleep 1 && \
 			$(MAKE); \
 	done

--- a/stylesheets/common.xsl
+++ b/stylesheets/common.xsl
@@ -25,8 +25,10 @@ body {
   background: white;
 }
   </style>
-  <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"/>
-  <script src="../static/respec-main.js"></script>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer">
+<xsl:comment>Dummy comment to defeat self-closing tags for XML/XHTML output.</xsl:comment></script>
+  <script src="../static/respec-main.js">
+<xsl:comment>Dummy comment to defeat self-closing tags for XML/XHTML output.</xsl:comment></script>
   <script class="remove">
 window.plantuml_host = '<xsl:value-of select="mbse/@plantuml_host"/>/plantuml/svg/';
 window.idef0svg_host = '<xsl:value-of select="mbse/@idef0svg_host"/>/svg/';

--- a/stylesheets/logical_and_physical_architecture.xsl
+++ b/stylesheets/logical_and_physical_architecture.xsl
@@ -4,7 +4,7 @@
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:include href="common.xsl" />
-<xsl:output method="html" indent="yes" />
+<xsl:output method="xml" indent="yes" />
 
 <xsl:template match="/">
   <html>

--- a/stylesheets/network.xsl
+++ b/stylesheets/network.xsl
@@ -3,7 +3,7 @@
 <xsl:stylesheet version="1.0"
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-<xsl:output method="html" indent="yes" />
+<xsl:output method="xml" indent="yes" />
 
 <xsl:template match="/">
 <html>

--- a/stylesheets/originating_requirements.xsl
+++ b/stylesheets/originating_requirements.xsl
@@ -4,7 +4,7 @@
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:include href="common.xsl"/>
-<xsl:output method="html" indent="yes" />
+<xsl:output method="xml" indent="yes" />
 
 <xsl:key name="group_id" match="reference" use="@stakeholder" />
 

--- a/stylesheets/product_requirements_specifications.xsl
+++ b/stylesheets/product_requirements_specifications.xsl
@@ -5,16 +5,15 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:include href="common.xsl"/>
 
-<xsl:output method="html" indent="yes" />
+<xsl:output method="xml" indent="yes" />
 <xsl:key name="group_id" match="//categories" use="@group"/>
 
 <xsl:template match="/">
   <html>
   <head>
   <title>Product requirements specification</title>
-  <link rel="stylesheet" href="https://github.com/tabatkins/railroad-diagrams/raw/gh-pages/railroad.css"/>
-  <script src="https://github.com/tabatkins/railroad-diagrams/raw/gh-pages/railroad.js"></script>
-  <script id="MathJax-script" async="async" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  <script id="MathJax-script" async="async" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
+      <xsl:comment>Dummy comment to defeat XML/XHTML self-pairing tags.</xsl:comment></script>
   <xsl:apply-templates select="." mode="scripts"/>
   </head>
   <body>

--- a/stylesheets/use_cases.xsl
+++ b/stylesheets/use_cases.xsl
@@ -4,7 +4,7 @@
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:include href="common.xsl"/>
-<xsl:output method="html" indent="yes" />
+<xsl:output method="xml" indent="yes" />
 
 <xsl:template match="/">
   <html>


### PR DESCRIPTION
Configure `xsltproc` to generate valid XHTML1.0 output (also known as "strict" mode): https://www.w3.org/TR/xhtml1/

> [!NOTE]
> Modern web browser can still handle HTML5 features, e.g. `<canvas>`, `<video>`, and `<svg>`. So, there is no concern for degraded user experiences yet.

The benefits of XHTML1.0 over HTML5 output are two prong:

- Better handling of empty elements with self-pairing XML tag syntax; and

- enables downstream document processing, e.g. embeddiing engineering block diagrams (in SVG) with Python `xml.etree` library;

Also, remove the Railroad diagram depdendencies. Currently, we do not have an XSLT template to render `<railroad>...</railroad>` into `<script>...</script>`. We can bring it back in the future.