### PR TITLE
Self-documenting MBSE-lite archtecture requirements

### DIFF
--- a/design-input/6_architecture/company-hosted-rendering.xml
+++ b/design-input/6_architecture/company-hosted-rendering.xml
@@ -1,0 +1,47 @@
+<architecture id="lad-2" status="initial" is_logical="true">
+  <uml>
+rectangle "Company firewall" {
+  actor "System authors" as Authors
+  actor "Admin"
+
+  node "Company laptops" {
+    rectangle "Company laptop firewall" {
+      artifact "mbse-lite model" as model
+
+      artifact "Generated reports" as report
+      <this ref="int-7"/>
+      <this ref="int-1" />
+      <this ref="int-2" />
+    }
+  }
+
+  node "Company server" as server {
+    [PlantUML rendering service] -up- <this ref="int-3" />
+    [IDEF0 rendering service] -up- <this ref="int-4" />
+  }
+
+  model -up- <this ref="int-1"/>
+  report -up- <this ref="int-7"/>
+  server -- <this ref="int-5" />
+
+  report ..> <this ref="int-3"/>: renders
+  report ..> <this ref="int-4"/>: renders
+  Authors ..> <this ref="int-1" />: edits
+  Authors ..> <this ref="int-2" />: edits
+  Authors ..> <this ref="int-7" />: reviews
+  Admin ..> <this ref="int-5" />
+}
+
+  </uml>
+  <description brief="Company-hosted rendering environment">Company laptops keep proprietary XML models local while shared PlantUML and IDEF0 rendering servers handle diagram generation behind the company firewall.</description>
+  <interface id="int-4" external="true">
+    <description brief="IDEF0 diagram rendering interface">Company laptops request rendered IDEF0 figures from a shared internal rendering service.</description>
+    <software>The interface shall provide RESTful IDEF0 rendering within the company network.</software>
+    <software>The interface SHALL encode / escape the IDEF0 code in Base64 encoding [[RFC4648]].</software>
+    <software>The interface SHALL NOT encrypt the incoming or outgoing data. It is the responsibility of the company network and the firewall.</software>
+  </interface>
+  <interface id="int-5" external="true">
+    <description brief="Power user interface">Root / administrator access to the company server.</description>
+    <software>The interface SHALL be password / SSH key protected.</software>
+  </interface>
+</architecture>

--- a/design-input/6_architecture/company-network.xml
+++ b/design-input/6_architecture/company-network.xml
@@ -1,0 +1,40 @@
+<architecture id="pad-2" status="initial">
+  <uml>
+cloud "GitHub" {
+  artifact "mbse-lite data backup"
+}
+
+rectangle "Company firewall and gateway" {
+actor "Non-technical authors" as Authors
+actor "Admin"
+
+node "Company laptops" as laptop {
+  artifact "Generated reports"
+}
+<this ref="int-8"/>
+<this ref="int-10"/>
+
+node "Printers"
+node "Company server" as server
+<this ref="int-5"/>
+
+  artifact "Printed reports" as paper
+}
+
+Printers -up- <this ref="int-5"/>
+server -up- <this ref="int-5"/>
+laptop -up- <this ref="int-8"/>
+laptop -- <this ref="int-10"/>
+
+Authors ..> <this ref="int-8" />
+Printers ..> paper: prints
+Admin ..> <this ref="int-5" />
+  </uml>
+  <description brief="Company laptops and rendering servers">Company laptops host proprietary mbse-lite models while shared PlantUML and IDEF0 servers render figures inside the protected company network.</description>
+  <interface id="int-10" external="true">
+    <description brief="Company Ethernet / WiFi">Secure wired / wireless connections to access the company servers.</description>
+    <software>The interface, if wireless, SHALL encrypt incoming and outgoing data.</software>
+    <software>The throughput SHALL be &gt; 1 MB/s, so that the system diagrams can be rendered promptly.</software>
+    <implements ref="int-3"/>
+  </interface>
+</architecture>

--- a/design-input/6_architecture/personal-laptop-public-wifi.xml
+++ b/design-input/6_architecture/personal-laptop-public-wifi.xml
@@ -1,0 +1,35 @@
+<architecture id="pad-1" status="initial">
+  <uml>
+left to right direction
+cloud "Internet"
+<this ref="int-6"/> as WiFi
+<this ref="int-8"/> as keyboard
+
+actor "Author" as Author
+node "Personal laptop" as laptop
+
+<![CDATA[
+
+Author ..> keyboard
+laptop -left- keyboard
+laptop ..> WiFi
+Internet -left- WiFi
+
+]]>
+  </uml>
+  <description brief="Personal laptop on public WiFi">A personal laptop hosts the mbse-lite checkout, XML models, and generated reports while public WiFi provides optional access to remote PlantUML rendering.</description>
+  <interface id="int-6" external="true">
+    <description brief="Public WiFi">Unprotected wired / wireless connection, e.g. hotel room, cafe, or train WiFi.
+      Assume unprotected data transfer (e.g. [[HTTP11]] plain text protocol rather than HTTPS).</description>
+    <software>The interface shall operate on files stored in the local mbse-lite checkout.</software>
+    <implements ref="int-3"/>
+  </interface>
+  <interface id="int-8" external="true">
+    <description brief="Keyboard">A physical `QWERTY` keyboard. MBSE-lite is meant to be written in plain English, but is not strictly a diagramming tool.
+       Mouse access is optional.</description>
+    <mechanical>The keyboard can be either `QWERTY` or `DVORAK`.</mechanical>
+    <software>The keyboard SHALL support international languages, e.g. French or
+    Chinese, in order to interact with international hardware/software
+    vendors.</software>
+  </interface>
+</architecture>

--- a/design-input/6_architecture/self-hosted-editing.xml
+++ b/design-input/6_architecture/self-hosted-editing.xml
@@ -1,0 +1,76 @@
+<architecture id="lad-1" status="initial" is_logical="true">
+  <uml>
+left to right direction
+actor "Non-technical author" as Author
+actor "Professional author" as Prof
+node "Personal laptop" {
+  artifact "Generated reports" as html_doc
+
+  <this ref="int-7"/>
+  <this ref="int-2" />
+
+  component "Integrated development environment (IDE)" as IDE
+
+  database "Filesystem" {
+    artifact "mbse-lite model" as model
+    <this ref="int-1" />
+  }
+  <this ref="int-9"/>
+}
+cloud "Public PlantUML server" as PublicPlantUML
+
+model - <this ref="int-1"/>
+IDE - <this ref="int-2"/>
+html_doc - <this ref="int-7"/>
+PublicPlantUML - <this ref="int-3" />
+Filesystem -down- <this ref="int-9"/>
+
+Author ...> <this ref="int-1" />: edits
+Prof ...> <this ref="int-2" />
+Author ...> <this ref="int-7"/>: reviews
+html_doc ...> <this ref="int-3"/>: renders
+  </uml>
+  <description brief="Self-hosted editing environment for open-source projects">A personal editing
+  workflow lets a non-technical author maintain MBSE-lite XML models locally and
+  run make occasionally to preview generated reports.
+
+  <aside class="note">Note: Open source projects only.</aside>
+</description>
+  <interface id="int-1" external="true">
+    <description brief="Plain text editor">The author edits XML system models
+    with a plain text editor on a personal laptop.</description>
+    <mechanical>Editing is keyboard oriented, not mouse oriented, for source
+    version control (VCS) purposes.</mechanical>
+    <software>The interface SHALL preserve plain XML files without requiring an
+    MBSE-specific editor application.</software>
+  </interface>
+  <interface id="int-2" external="true">
+    <description brief="Code editing interface">(Optional) The author may use an integrated development environment (IDE) for navigation,
+    search, and XML editing without changing the model format.</description>
+    <software>The interface SHALL expose the same repository files used by
+    vanilla text editors.</software>
+    <software>The interface SHALL have a file browser for quick navigation of
+    all nested folders and XML files.</software>
+  </interface>
+  <interface id="int-3" external="true">
+    <description brief="PlantUML service">A web service that converts PlantUML code to images.</description>
+
+    <software>The interface SHALL send PlantUML text over a RESTful web
+    interface and receive rendered figures.</software>
+    <software>The interface SHALL encode / escape the PlantUML code in Base64 encoding [[RFC4648]].</software>
+    <software>The interface SHALL NOT encrypt the incoming or outgoing data. It
+    is the end user's responsibility to edit / review open source designs
+    only on personal laptops.</software>
+  </interface>
+  <interface id="int-7" external="true">
+    <description brief="Web browser">A document viewer that also supports static
+    figure rendering, hyperlinks, and limited forms of dynamic
+    scripts.</description>
+    <software>The interface SHALL support vector drawings, likely [[SVG]].</software>
+  </interface>
+  <interface id="int-9">
+    <description brief="Filesystem events">An interactive interface to invoke
+    product requirement report generation on demand. Likely used by Linux
+    `inotify` daemon to detect file changes.</description>
+  </interface>
+</architecture>


### PR DESCRIPTION
Capture MBSE-lite's implicit design decisions with the MBSE schema on its own (known as self-documentation). The requirements are captured bottom-up, i.e. starting from synthesized architctures back to functional requirements and use-cases, rather than top-down because MBSE-lite is already in production.

This pull request aims to clarify the separation of concerns with `to_offline.py` scripts and `to_pdf.py` scripts, and to reason about the `monorepo` approach versus `collection of git-repo` approaches to figure rendering features and model composition features.

Related to : #21 , #24

<img width="1042" height="772" alt="image" src="https://github.com/user-attachments/assets/85e1e274-a077-4646-adb8-57781d716549" />
